### PR TITLE
Update GitHub URL

### DIFF
--- a/korjaus.md
+++ b/korjaus.md
@@ -14,7 +14,7 @@ permalink: /korjaus/
 ## Typoja materiaalissa
 
 Kun huomaat näillä sivuilla kirjoitusvirheitä tai muita heikkouksia, tee korjausehdotus. Kurssimateriaali on repositoriossa
-[https://github.com/jezberg/algoLabra](https://github.com/jezberg/algoLabra) tiedostoissa [testaus.md](https://github.com/jezberg/algoLabra) jne.
+[https://github.com/algolabra-hy/algolabra-hy.github.io/](https://github.com/algolabra-hy/algolabra-hy.github.io/) tiedostoissa [testaus.md](https://github.com/jezberg/algoLabra) jne.
 
 Muutosehdotuksen tekeminen aloitetaan painamalla tiedoston _kynä-symbolia_:
 


### PR DESCRIPTION
Just a small fix, had some trouble finding this up-to-date repo from the course page