### PR TITLE
Update self-referential GitHub URL

### DIFF
--- a/korjaus.md
+++ b/korjaus.md
@@ -14,7 +14,7 @@ permalink: /korjaus/
 ## Typoja materiaalissa
 
 Kun huomaat näillä sivuilla kirjoitusvirheitä tai muita heikkouksia, tee korjausehdotus. Kurssimateriaali on repositoriossa
-[https://github.com/algolabra-hy/algolabra-hy.github.io/](https://github.com/algolabra-hy/algolabra-hy.github.io/) tiedostoissa [testaus.md](https://github.com/jezberg/algoLabra) jne.
+[https://github.com/algolabra-hy/algolabra-hy.github.io/](https://github.com/algolabra-hy/algolabra-hy.github.io/). Esimerkiksi tämä sivu löytyy tiedostosta [korjaus.md](https://github.com/algolabra-hy/algolabra-hy.github.io/blob/main/korjaus.md).
 
 Muutosehdotuksen tekeminen aloitetaan painamalla tiedoston _kynä-symbolia_:
 


### PR DESCRIPTION
Makes sense to link to the page itself as a concrete example; also, updates pointed to repo to new one.

This was meant to be a part of #3, but maintainer was faster than I expected in merging it 😅 