### PR TITLE
Remove example project with broken link

### DIFF
--- a/_pages/en/examples_of_projects.md
+++ b/_pages/en/examples_of_projects.md
@@ -14,7 +14,6 @@ We ask for separate permission to present assignments on these pages.
 - Sari Bäckman, [Scientific Calculator (Python)](https://github.com/sari-bee/tieteellinen_laskin)
 - Olivia Brotherus, [Spell Checker (Python)](https://github.com/brotholi/tiralabra)
 - Joona Kettunen, [Path-Finding Algorithm Comparison (Typescript)](https://github.com/joonarafael/visualpathfinder)
-- Pekka Linna [DPLL](https://github.com/pekkalin/Algolabra/) 
 
 
 {% include typo_instructions_en.md %}

--- a/_pages/fin/examples_of_projects.md
+++ b/_pages/fin/examples_of_projects.md
@@ -17,7 +17,6 @@ Pyydämme eriksen lupaa harjoitustöiden esittelemiseen näillä sivuilla.
 - Sari Bäckman, [Tieteellinen laskin](https://github.com/sari-bee/tieteellinen_laskin) (Python)
 - Olivia Brotherus, [Kirjoitusvirheiden korjaus](https://github.com/brotholi/tiralabra) (Python)
 - Joona Kettunen, [Reitinhakualgoritmien vertailu](https://github.com/joonarafael/visualpathfinder) (Typescript)
-- Pekka Linna [DPLL](https://github.com/pekkalin/Algolabra/) (Python)
 
 
 {% include typo_instructions_fin.md %}


### PR DESCRIPTION
Remove the DPLL example project from both finnish and english example projects because the link to the project is either broken or not public.